### PR TITLE
fix(): Sort versions

### DIFF
--- a/functions/lambda-version-cleaner/app.py
+++ b/functions/lambda-version-cleaner/app.py
@@ -97,7 +97,7 @@ def lambda_handler(event, context):
 
         # Loop through all functions and remove old versions
         for function in functions:
-            versions = get_function_versions(function, region)
+            versions = sorted(get_function_versions(function, region), key=int, reverse=True)
             alias_versions = get_function_alias_versions(
                 function["function_name"], region
             )

--- a/functions/lambda-version-cleaner/app.py
+++ b/functions/lambda-version-cleaner/app.py
@@ -54,6 +54,7 @@ def get_function_versions(function: Dict[str, str], region: str) -> List[str]:
                 for version in page
                 if version["Version"] != function["version"]
             ],
+            key=int,
             reverse=True,
         )
     except ClientError as e:
@@ -97,7 +98,7 @@ def lambda_handler(event, context):
 
         # Loop through all functions and remove old versions
         for function in functions:
-            versions = sorted(get_function_versions(function, region), key=int, reverse=True)
+            versions = get_function_versions(function, region)
             alias_versions = get_function_alias_versions(
                 function["function_name"], region
             )


### PR DESCRIPTION
As the title says. Sort the returned versions from the `list_versions_by_function` call based on the integer values of the strings rather than their lexicographical order as it is not guaranteed to be in sorted order in the response.

Before:
The returned versions for function `get_function_versions` was originally as tested for `pd-atlas-platforms-create`:
```
['99', '98', '97', '96', '95', '94', '93', '92', '91', '90', '313']
```

After:
The returned versions for function `get_function_versions` was originally as tested for `pd-atlas-platforms-create`:
```
['313', '99', '98', '97', '96', '95', '94', '93', '92', '91', '90']
```